### PR TITLE
Fix bug where page upper bound could be greater than queryRecordCount

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -932,7 +932,7 @@
       pageBounds: function() {
         var page = settings.dataset.page || 1,
             first = (page - 1) * settings.dataset.perPage,
-            last = first + Math.min(settings.dataset.perPage, settings.dataset.queryRecordCount);
+            last = Math.min(first + settings.dataset.perPage, settings.dataset.queryRecordCount);
         return [first,last];
       },
       // get initial recordset to populate table


### PR DESCRIPTION
I just had the page count say '1 - 18 of 16'... the code that checks for that scenario wasn't working right so I fixed it.
