### PR TITLE
Fixed hidden rows if header cell was set to hidden

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -282,7 +282,7 @@
 
     // keep cells for hidden column headers hidden
     if (column.hidden) {
-      td += ' display="none"';
+      td += ' style="display:none;"';
     }
 
     // keep cells aligned as their column headers are aligned


### PR DESCRIPTION
If header cell was set to hidden, the cells within that column were given an attribute "display=none" which is not a valid html attribute. Switched it so that the cells get attribute style="display:none;" which actually hides them. 
