### PR TITLE
Adding inputs option for "Search:" label

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -84,7 +84,7 @@
       perPageText: 'Show: ',
       recordCountText: 'Showing ',
       processingText: 'Processing...',
-      searchFieldText: 'Search:'
+      searchFieldText: 'Search: '
     },
     dataset: {
       ajax: false,


### PR DESCRIPTION
Hi ! 

I'm using dynatable for my website and I just saw that the label "Search:" near the search field is not easily changeable. 

So I create an option, just like you did at first, to modify the label.

I tested it just now and it's working great.

I hope it will fill your requirements.

Thank you for your work.

Added an input option to modify the "Search:" label near the search field.
