### PR TITLE
Add 'dynatable-loaded' class to table when processing is complete

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -280,7 +280,7 @@
       }
     }
 
-    this.$element.addClass('dynatable-processed');
+    this.$element.addClass('dynatable-loaded');
     this.$element.trigger('dynatable:afterProcess', data);
   };
 


### PR DESCRIPTION
I needed this to avoid having the original table flash up before Dynatable had finished working on it. _e.g. with_

``` css
#some-table {
   visibility: hidden;
}

#some-table.dynatable-loaded {
    visibility: visible;
}
```

but debating whether it deserves to be in the core or my own event handler instead.
