### PR TITLE
fix #67 | provide a way to clear the queries array

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1137,6 +1137,12 @@
       return dt;
     };
 
+    this.clear = function() {
+      settings.dataset.queries = {};
+      // not sure what the event arg should be if I trigger teh :removed event
+      return dt;
+    }
+
     this.run = function() {
       for (query in settings.dataset.queries) {
         if (settings.dataset.queries.hasOwnProperty(query)) {


### PR DESCRIPTION
Tested with the following cases: 

```
dynatable.queries.add('rank', 4);
dynatable.queries.add('country', 'Chile');

dynatable.process();

dynatable.queries.clear();

dynatable.process();
```
