### PR TITLE
Fix unhandled exception if urlOptions isn't defined

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1595,7 +1595,7 @@
                 if (typeof urlOptions[label] === 'undefined') { urlOptions[label] = {}; }
                 urlOptions[label][attr] = data[label][attr];
               } else {
-                delete urlOptions[label][attr];
+                if (urlOptions && urlOptions[label] && urlOptions[label][attr]) { delete urlOptions[label][attr]; }
               }
             }
             continue;


### PR DESCRIPTION
This fixes unhandled errors when using custom query functions.
