### PR TITLE
Add option to not reset page when adding a filter query

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1121,9 +1121,9 @@
       }
     };
 
-    this.add = function(name, value, noPageReset) {
-      // only reset the page if noPageReset is not enabled and the filter is not already applied
-      if (settings.features.paginate && !noPageReset && (!settings.dataset.queries[name] || settings.dataset.queries[name] != value)) {
+    this.add = function(name, value, skipPageReset) {
+      // only reset the page if skipPageReset is not enabled and the filter is not already applied
+      if (settings.features.paginate && !skipPageReset && (!settings.dataset.queries[name] || settings.dataset.queries[name] !== value)) {
         settings.dataset.page = 1;
       }
       settings.dataset.queries[name] = value;


### PR DESCRIPTION
Currently, adding a custom query method always resets the page. However, this is not always the desired behavior. For example, it may be necessary to add custom query methods as part of the init process without resetting the page (so that page links and bookmarks will work).

Additionally, the page should only be reset if the filter is not already applied. This allows navigation between pages when a filter is applied to work correctly with back/forward buttons.
