### PR TITLE
Only call Array.sort() if sort columns/keys are specified

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -644,9 +644,7 @@
       }
 
       if (sortsKeys.length > 0 || !$.isEmptyObject(sorts)) {
-        return sort.call(settings.dataset.records, sortFunction);
-      } else {
-        return settings.dataset.records;
+        sort.call(settings.dataset.records, sortFunction);
       }
     };
 


### PR DESCRIPTION
Fixes issue #87
