### PR TITLE
fix for multiple custom queries

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1594,7 +1594,7 @@
               if (data[label][attr]) {
                 if (typeof urlOptions[label] === 'undefined') { urlOptions[label] = {}; }
                 urlOptions[label][attr] = data[label][attr];
-              } else {
+              } else if(urlOptions[label]) {
                 delete urlOptions[label][attr];
               }
             }


### PR DESCRIPTION
Check to see if queries is a property of the urlOptions object, before
deleting the current input from the query.  Without this check, the
script was throwing an Uncaught TypeError: "Cannot convert undefined or
null to object" when all the following conditions were met:
1. there is more than one custom queries
2. there is none currently in use
3. the user tries to use any, but the first one found by the selector in
   the dom (when using the first one found by the selector, the problem
   doesn't appear).

Seems to be related with this issue:
https://github.com/alfajango/jquery-dynatable/issues/73
