### PR TITLE
Avoid Uncaught TypeError

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -960,8 +960,8 @@
         var aAttr = (a['dynatable-sortable-text'] && a['dynatable-sortable-text'][attr]) ? a['dynatable-sortable-text'][attr] : a[attr],
             bAttr = (b['dynatable-sortable-text'] && b['dynatable-sortable-text'][attr]) ? b['dynatable-sortable-text'][attr] : b[attr],
             comparison;
-        aAttr = aAttr.toLowerCase();
-        bAttr = bAttr.toLowerCase();
+        aAttr = aAttr ? aAttr.toLowerCase() : (aAttr+"").toLowerCase();
+        bAttr = bAttr ? bAttr.toLowerCase() : (bAttr+"").toLowerCase();
         comparison = aAttr === bAttr ? 0 : (direction > 0 ? aAttr > bAttr : bAttr > aAttr);
         // force false boolean value to -1, true to 1, and tie to 0
         return comparison === false ? -1 : (comparison - 0);


### PR DESCRIPTION
When JSON contains record with null or undefined element,
Sort by string will fail with `Uncaught TypeError: Cannot read property 'toLowerCase' of null`
And dynatable process will hang up.

This PR fix that error.

I know that we can use custom sort function. But it would be nice if dynatable handle unexpected input.
http://jsfiddle.net/georgeosddev/cR3p8/2/
