### PR TITLE
ajaxComplete and ajaxDone customization

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -595,7 +595,6 @@
       // Create cache of original full recordset (unpaginated and unqueried)
       settings.dataset.originalRecords = $.extend(true, [], settings.dataset.records);
     };
-    console.log(obj)
     this.ajaxSuccess = obj.settings.ajax.ajaxSuccess
     this.ajaxDone = obj.settings.ajax.ajaxDone
 


### PR DESCRIPTION
I needed to have more flexibility with ajaxComplete and ajaxDone.  The changes I've made allow you to swap in your own ajaxComplete and ajaxDone functions.   In my case, I'm using jquery.when() to require additional data, and then further updating the data returned by the dynatable ajax requested.

Just create a handler for the dynatable:preinit function to swap in your functions.

$('.dynatable').on('dynatable:preinit', function(el, dyna) {
  dyna.settings.ajax.ajaxSuccess = yourSuccessFunction;
  return dyna.settings.ajax.ajaxDone = yourDoneFunction;
})

Be gentle, javascript is definitely not my strong suit :)
