### PR TITLE
Trigger event on ajax error

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -233,6 +233,7 @@
         dataType: _this.settings.dataset.ajaxDataType,
         data: data,
         error: function(xhr, error) {
+          _this.$element.trigger('dynatable:ajax:error', {xhr: xhr, error : error});
         },
         success: function(response) {
           _this.$element.trigger('dynatable:ajax:success', response);


### PR DESCRIPTION
My application requires that all ajax errors should be handled in the same way.

Since dynatables 'dies silently' on an ajax error, I added this event trigger.
