### PR TITLE
the queryRecordCount parameters not necessary

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -609,7 +609,7 @@
           records[i] = records[i][settings.params.record];
         }
       }
-      if (settings.params.queryRecordCount in data) {
+      if ((settings.dataset.page === 1) && (settings.params.queryRecordCount in data)) {
         settings.dataset.queryRecordCount = data[settings.params.queryRecordCount];
       }
       if (settings.params.totalRecordCount in data) {


### PR DESCRIPTION
We only need to count the queryRecordCount once when page === 1. 
If we change to other pages this variable stay the same and doesn't need to be compute by the backend.

The best one would be to have a button 'last page' and never have to compute queryRecordCount.
