### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "dynatable",
   "description": "A funner, semantic, HTML5+JSON, interactive table plugin.",
-  "version": "0.3.1",
   "keywords": [
     "table",
     "datatables",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property