### PR TITLE
Hide pageText if evaluates to false

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1386,7 +1386,9 @@
             (pages + 1) - settings.inputs.paginationGap[3]
           ];
 
-      pageLinks += '<li><span>' + settings.inputs.pageText + '</span></li>';
+      if (settings.inputs.pageText) {
+        pageLinks += '<li><span>' + settings.inputs.pageText + '</span></li>';
+      }
 
       for (var i = 1; i <= pages; i++) {
         if ( (i > breaks[0] && i < breaks[1]) || (i > breaks[2] && i < breaks[3])) {


### PR DESCRIPTION
This PR checks whether `settings.inputs.pageText` evaluates to true. If not, it hides the extra span in the pagination (which by default has the text "Pages: ").