### PR TITLE
Adding the originalTR to the record object

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -675,6 +675,7 @@
       tableRecords.each(function(index){
         var record = {};
         record['dynatable-original-index'] = index;
+        record["originalTR"] = $(this);
         $(this).find('th,td').each(function(index) {
           if (columns[index] === undefined) {
             // Header cell didn't exist for this column, so let's generate and append


### PR DESCRIPTION
I made this change in my project because I added a CSS class to certain rows (such as rows to indicate an error). This change allows you to view or access the original tr so that you can copy the CSS class that was applied to it and apply the CSS class to the new tr generation. I'm sure there are better ways to achieve this - but this was my quick patch to get what I needed working.

Example:

    function defaultRowWriter(rowIndex, record, columns, cellWriter) {
        var tr = '';


        // grab the record's attribute for each column
        for (var i = 0, len = columns.length; i < len; i++) {
          tr += cellWriter(columns[i], record);
        }

        return '<tr class="' + record.originalTR[0].className + '">' + tr + '</tr>';
      };