### PR TITLE
CSRF token in Ajax request

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -232,6 +232,13 @@
         type: _this.settings.dataset.ajaxMethod,
         dataType: _this.settings.dataset.ajaxDataType,
         data: data,
+        beforeSend: function(request){
+        	var token = $("meta[name='_csrf']").attr("content");
+        	if (!token) token = "";
+        	var header = $("meta[name='_csrf_header']").attr("content");
+        	if (!header) header = "";
+            request.setRequestHeader(header, token);
+        },
         error: function(xhr, error) {
           _this.$element.trigger('dynatable:ajax:error', {xhr: xhr, error : error});
         },


### PR DESCRIPTION
Add CSRF token to Ajax request if there are existing in META.

Usefull for example if your are using a framework on server-side which protect you from CSRF attack. Like spring-security framework.

Following line are included in the Ajax Request Header : 

   X-CSRF-Token	8e891092-3483-48b7-a0e3-f5413eb489fe