### PR TITLE
handle null value fields better

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -326,7 +326,7 @@
   function defaultAttributeWriter(record) {
     // `this` is the column object in settings.columns
     // TODO: automatically convert common types, such as arrays and objects, to string
-    return record[this.id];
+    return record[this.id] || '';
   };
 
   function defaultAttributeReader(cell, record) {
@@ -958,8 +958,8 @@
         return a[attr] === b[attr] ? 0 : (direction > 0 ? a[attr] - b[attr] : b[attr] - a[attr]);
       },
       string: function(a, b, attr, direction) {
-        var aAttr = (a['dynatable-sortable-text'] && a['dynatable-sortable-text'][attr]) ? a['dynatable-sortable-text'][attr] : a[attr],
-            bAttr = (b['dynatable-sortable-text'] && b['dynatable-sortable-text'][attr]) ? b['dynatable-sortable-text'][attr] : b[attr],
+        var aAttr = ((a['dynatable-sortable-text'] && a['dynatable-sortable-text'][attr]) ? a['dynatable-sortable-text'][attr] : a[attr]) || '',
+            bAttr = ((b['dynatable-sortable-text'] && b['dynatable-sortable-text'][attr]) ? b['dynatable-sortable-text'][attr] : b[attr]) || '',
             comparison;
         aAttr = aAttr.toLowerCase();
         bAttr = bAttr.toLowerCase();


### PR DESCRIPTION
rows with null entries would not sort with the default string sort function. Also null fields would print 'null' instead of a blank string which is not that desirable in most cases when trying to show a datatable. This fixes both issues.