### PR TITLE
added a texttransform for 'none' which leaves column names as-is

### DIFF
--- a/jquery.dynatable.js
+++ b/jquery.dynatable.js
@@ -1490,6 +1490,9 @@
       },
       lowercase: function(text) {
         return text.replace(/([A-Z])/g, function($1){return $1.toLowerCase();});
+      },
+      none: function(text) {
+        return text;
       }
     },
     // Deserialize params in URL to object


### PR DESCRIPTION
Just added a simple 'none' text transform as per comments here:

https://github.com/alfajango/jquery-dynatable/issues/70
